### PR TITLE
collectd calls: handle applications with no instance

### DIFF
--- a/xivo_bus/collectd/calls.py
+++ b/xivo_bus/collectd/calls.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2016-2018 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import unicode_literals
@@ -29,9 +29,11 @@ class CallCollectdEvent(CollectdEvent):
             self.time = int(time)
 
         application = validate_plugin_instance_fragment(application)
-        application_id = validate_plugin_instance_fragment(application_id)
-
-        self.plugin_instance = '{}.{}'.format(application, application_id)
+        if application_id is not None:
+            application_id = validate_plugin_instance_fragment(application_id)
+            self.plugin_instance = '{}.{}'.format(application, application_id)
+        else:
+            self.plugin_instance = application
 
 
 class CallStartCollectdEvent(CallCollectdEvent):

--- a/xivo_bus/collectd/tests/test_calls.py
+++ b/xivo_bus/collectd/tests/test_calls.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016 Proformatique Inc.
+# Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import unicode_literals
@@ -13,10 +13,16 @@ from ..calls import CallCollectdEvent
 
 
 class TestCallCollectdEvent(TestCase):
+
     def test_plugin_instance_validation_when_empty(self):
         event = CallCollectdEvent('', '')
 
         assert_that(event.plugin_instance, equal_to('<unknown>.<unknown>'))
+
+    def test_plugin_validation_when_no_instance(self):
+        event = CallCollectdEvent('', None)
+
+        assert_that(event.plugin_instance, equal_to('<unknown>'))
 
     def test_plugin_instance_validation_when_only_invalid_chars(self):
         event = CallCollectdEvent('_&!* <,(*&^ .%#@$#)&(^', 'ééé')


### PR DESCRIPTION
when a pjsip endpoint has a stasis-<app> as the context there are no arguments
given to the application and no instance.